### PR TITLE
I've updated the countdown timer to use the value of 'period.'

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,7 +264,7 @@
                 if (!totp1) return;
                 
                 const now = Math.floor(Date.now() / 1000);
-                const remaining = 30 - (now % 30);
+                const remaining = period - (now % period);
                 
                 document.getElementById('otpDisplay1').textContent = totp1.generate();
                 document.getElementById('countdown').textContent = remaining;


### PR DESCRIPTION
While it's not exposed to the browser user, someone might want to extend the time slightly - or even not slightly - to make the system more usable for some folks. This way if the value for period is changed from its default 30 seconds it won't be necessary to change it in the updateOtpDisplay code to match.