### PR TITLE
Space out the QR codes on the page

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
             <span data-i18n="base32secret"></span><br>
             <span id="secret" class="font-monospace"></span>
         </p>
-        <div class="row justify-content-center gx-0">
+        <div class="row justify-content-between gx-0">
             <div class="col-12 col-md-3 gy-5 text-center qr-column">
                 <p><span id="label1"></span><span data-i18n="pleaseScan">, please scan the QR code below:</span></p>
                 <div id="qrcode1" class="d-flex justify-content-center"></div>


### PR DESCRIPTION
When you bring up your QR code reader on your camera you need to be careful about which you hit, or you need to cover one with your hand.

This change simply shoves them further apart on the page to make it less likely your camera sees both in the view.



---------

Before:
<img width="1107" alt="image" src="https://github.com/user-attachments/assets/2e74c8f0-5303-4c77-80f2-75582176a368" />



After:

<img width="1152" alt="image" src="https://github.com/user-attachments/assets/6d18d77b-38d4-4cf6-bd62-b2088d20b753" />

